### PR TITLE
Fix issue where temporary render texture was not cleared

### DIFF
--- a/Assets/Easy Icon Maker/Drawing/HandlerCameraRender.cs
+++ b/Assets/Easy Icon Maker/Drawing/HandlerCameraRender.cs
@@ -28,6 +28,10 @@ namespace EasyIconMaker
             RenderTexture oldTexture = captureCamera.targetTexture;
             RenderTexture targetTexture = RenderTexture.GetTemporary(size, size, 16, RenderTextureFormat.ARGB32);
 
+            RenderTexture tempActive = RenderTexture.active;
+            RenderTexture.active = targetTexture;
+            GL.Clear(true, true, Color.clear);
+
             if (texBG != null)
                 Graphics.Blit(texBG, targetTexture);
 
@@ -35,9 +39,6 @@ namespace EasyIconMaker
             captureCamera.targetTexture = targetTexture;
             captureCamera.forceIntoRenderTexture = true;
             captureCamera.Render();
-
-            RenderTexture tempActive = RenderTexture.active;
-            RenderTexture.active = targetTexture;
 
             Rect rect = new Rect(0, 0, size, size);
             texture.ReadPixels(rect, 0, 0);


### PR DESCRIPTION
Calling MakeImage multiple times in a single frame leads to weird results. Looking at the docs for  https://docs.unity3d.com/6000.3/Documentation/ScriptReference/RenderTexture.GetTemporary.html it looks like the RenderTexture generated by RenderTexture.CreateTemporary is not guaranteed to be cleared unless you wait a couple frames. This change makes sure the RT is cleared.